### PR TITLE
tweaks to build waxbee with newer toolchain

### DIFF
--- a/WaxB_Adb2Usb/Makefile
+++ b/WaxB_Adb2Usb/Makefile
@@ -1,6 +1,6 @@
 # Hey Emacs, this is a -*- makefile -*-
 #----------------------------------------------------------------------------
-# WinAVR Makefile Template written by Eric B. Weddington, Jörg Wunsch, et al.
+# WinAVR Makefile Template written by Eric B. Weddington, JÃ¶rg Wunsch, et al.
 #
 # Released to the Public Domain
 #
@@ -165,6 +165,8 @@ CFLAGS += -Wa,-adhlns=$(<:%.c=$(OBJDIR)/%.lst)
 CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 CFLAGS += $(CSTANDARD)
 
+# fix prog_char errors for C
+CFLAGS += -Wno-deprecated-declarations -D__PROG_TYPES_COMPAT__
 
 #---------------- Compiler Options C++ ----------------
 #  -g*:          generate debugging information
@@ -192,6 +194,8 @@ CPPFLAGS += -Wa,-adhlns=$(<:%.cpp=$(OBJDIR)/%.lst)
 CPPFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
 #CPPFLAGS += $(CSTANDARD)
 
+# fix prog_char errors for C++
+CPPFLAGS += -Wno-deprecated-declarations -D__PROG_TYPES_COMPAT__
 
 #---------------- Assembler Options ----------------
 #  -Wa,...:   tell GCC to pass this to the assembler.

--- a/WaxB_Adb2Usb/console.cpp
+++ b/WaxB_Adb2Usb/console.cpp
@@ -41,7 +41,7 @@ namespace console
 	}
 
 	/** @param progmem_str address of string stored in 'program memory'. */
-	void printP(prog_char* progmem_str)
+	void printP(const prog_char* progmem_str)
 	{
 		if(!console_enabled)
 			return;
@@ -58,7 +58,7 @@ namespace console
 	}
 
 	/** @param progmem_str address of string stored in 'program memory'. */
-	void printlnP(prog_char* progmem_str)
+	void printlnP(const prog_char* progmem_str)
 	{
 		printP(progmem_str);
 		println();

--- a/WaxB_Adb2Usb/console.h
+++ b/WaxB_Adb2Usb/console.h
@@ -25,9 +25,9 @@ namespace console
 	void print(const char* str);
 
 	/** @param progmem_str address of string stored in 'program memory'. */
-	void printP(prog_char* progmem_str);
+	void printP(const prog_char* progmem_str);
 	/** @param progmem_str address of string stored in 'program memory'. */
-	void printlnP(prog_char* progmem_str);
+	void printlnP(const prog_char* progmem_str);
 
 	void println();
 	void println(const char* str);

--- a/WaxB_Adb2Usb/frequency.cpp
+++ b/WaxB_Adb2Usb/frequency.cpp
@@ -1,6 +1,7 @@
 
 #include "frequency.h"
 
+#define __DELAY_BACKWARD_COMPATIBLE__
 #include <util/delay.h>
 #include "extdata.h"
 

--- a/WaxB_Adb2Usb/gpioinit.cpp
+++ b/WaxB_Adb2Usb/gpioinit.cpp
@@ -23,7 +23,7 @@ namespace GpioInit
 		return number;
 	}
 	
-	static void reportGpioErrorP(prog_char* progmem_str)
+	static void reportGpioErrorP(const prog_char* progmem_str)
 	{
 		console::printP(STR_GPIO_INIT);
 		console::printP(progmem_str);

--- a/WaxB_Adb2Usb/strings.c
+++ b/WaxB_Adb2Usb/strings.c
@@ -13,5 +13,5 @@
 #include "strings.h"
 
 // the string 0 is not a string but a 16 bit list of supported locale codes
-uint8_t PROGMEM usbdescriptor_string0[4] = { 4, 3, 0x04,0x09 };
+const uint8_t PROGMEM usbdescriptor_string0[4] = { 4, 3, 0x04,0x09 };
 

--- a/WaxB_Adb2Usb/strings.h
+++ b/WaxB_Adb2Usb/strings.h
@@ -21,16 +21,16 @@ extern "C"
 {
 #endif
 
-extern uint8_t PROGMEM usbdescriptor_string0[4];
+const extern uint8_t PROGMEM usbdescriptor_string0[4];
 
 // This header file will morph into its associated ".c" file if "STRINGS_C_" is #defined.
 // In other words, it will "create" the strings only in strings.c
 // strings.c is the only place that STRINGS_C_ is defined.
 
 #ifdef STRINGS_C_
-#define PSTRING(symbol, text) prog_char symbol[] = (text)
+#define PSTRING(symbol, text) const prog_char symbol[] = (text)
 #else
-#define PSTRING(symbol, text) extern prog_char symbol[]
+#define PSTRING(symbol, text) const extern prog_char symbol[]
 #endif
 
 //----------------------------------------------------------------


### PR DESCRIPTION
Tweaks to get waxbee to build with a newer toolchain (fixing const stuff and getting some deprecated things to work anyway).  Tested on ubuntu 14.04, which has avr-g++ 4.8.2.  I don't think these changes will cause issues with any other (older) compiler.
